### PR TITLE
devboxをインストール

### DIFF
--- a/features/vscode.nix
+++ b/features/vscode.nix
@@ -36,6 +36,7 @@
       asvetliakov.vscode-neovim
       marp-team.marp-vscode
       gera2ld.markmap-vscode
+      jetpack-io.devbox
     ];
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -56,6 +56,9 @@
     # gui tools
     zathura
 
+    # software-development
+    devbox
+
     # misc
     tree
     hyprshot


### PR DESCRIPTION
開発時の依存関係のバージョンを固定するためにnixpkgsのcommit hashを調べたり、パッケージのビルド成果物のハッシュを調べるペインが取り除かれそうなので、開発時の依存関係の管理はdevboxで行うことにした。